### PR TITLE
Replace "ready" for "mounted" hook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also use the `$subscribe(name, ...params)` method in you component code:
 
 
 ```javascript
-ready () {
+mounted () {
   // Subscribes to the 'threads' publication with two parameters
   this.$subscribe('thread', 'new', 10);
 }


### PR DESCRIPTION
Since `ready` is deprecated in Vue v2 and replaced with `mounted` it would be nice and less confusing to have updated here